### PR TITLE
Fix parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,9 @@
 _build
 
 # Ignore generated parser code
-lib/parser.ml
-lib/parser.mli
-lib/Parser.v
+driver/parser.ml
+driver/parser.mli
+theories/Parser.v
 
 # Remove Coq compiled code
 **/*.vo

--- a/theories/Parser.vy
+++ b/theories/Parser.vy
@@ -24,12 +24,12 @@ prog:
 
 obj:
   | LAMBDA args_list DOT obj {
-      List.fold_left (fun acc arg => Cst.Fun (fst arg) (snd arg) acc) $2 $4 
+      List.fold_left (fun acc arg => Cst.fn (fst arg) (snd arg) acc) $2 $4 
   }
   | PI args_list DOT obj {
-      List.fold_left (fun acc arg => Cst.Pi (fst arg) (snd arg) acc) $2 $4
+      List.fold_left (fun acc arg => Cst.pi (fst arg) (snd arg) acc) $2 $4
   }
-  | SUCC obj { Cst.Succ $2 }
+  | SUCC obj { Cst.succ $2 }
   (* Application is a special case, where we must avoid conflict by associativity: *)
   (* see https://github.com/utgwkk/lambda-chama/blob/master/parser.mly *)
   | app_obj { $1 }
@@ -46,14 +46,14 @@ args_obj:
 (* M N *)
 app_obj:
   (* simpl_obj prevents conflict by associativity *)
-  | app_obj simpl_obj { Cst.App $1 $2 }
+  | app_obj simpl_obj { Cst.app $1 $2 }
   | simpl_obj { $1 }
 
 (* Either a variable or parentheses around a complex object *)
 simpl_obj:
-  | VAR { Cst.Var $1 }
-  | NAT { Cst.Nat }
-  | ZERO { Cst.Zero }
-  | TYPE INT { Cst.TType $2 }
+  | VAR { Cst.var $1 }
+  | NAT { Cst.nat }
+  | ZERO { Cst.zero }
+  | TYPE INT { Cst.typ $2 }
   | LPAREN obj RPAREN { $2 }
 

--- a/theories/Syntax.v
+++ b/theories/Syntax.v
@@ -4,14 +4,14 @@ Require Import List.
 (* CST term *)
 Module Cst.
 Inductive obj : Set :=
-  | c_typ : nat -> obj
-  | c_nat : obj
-  | c_zero : obj
-  | c_succ : obj -> obj
-  | c_app : obj -> obj -> obj
-  | c_fn : string -> obj -> obj -> obj
-  | c_pi : string -> obj -> obj -> obj
-  | c_var : string -> obj.
+  | typ : nat -> obj
+  | nat : obj
+  | zero : obj
+  | succ : obj -> obj
+  | app : obj -> obj -> obj
+  | fn : string -> obj -> obj -> obj
+  | pi : string -> obj -> obj -> obj
+  | var : string -> obj.
 End Cst.
 
 (* AST term *)
@@ -36,6 +36,6 @@ with subst : Set :=
 
 (* Some convenient infix notations *)
 Infix "∘" := a_compose (at level 70).
-Infix "," := a_extend (at level 80).
+Infix ",," := a_extend (at level 80).
 
 Notation Ctx := (list exp).


### PR DESCRIPTION
Closes #17 . Sorry about all this. I forgot the implications of changing the CST term names, I thought it wasn't used anywhere. I should have been more careful.

What has been fixed:
- The `a_extend` notation "," was conflicting with parser compilation
- In addition, for the time being, the names of the CST terms have been reverted.

The parser will compile and you can use it in `utop`. The only caveat is that `test.ml` is completely broken right now due to the weird typing name stuff. I'll fix that in this branch.

From what I understand, the parser has been broken since 50790592232502d1435dbded066b3e5662a4f5b5 since I renamed the CST terms.