### PR TITLE
Add helper tactic for functional relations

### DIFF
--- a/theories/Core/Semantic/EvaluateLemmas.v
+++ b/theories/Core/Semantic/EvaluateLemmas.v
@@ -8,24 +8,24 @@ Section functional_eval.
   Let functional_eval_sub_prop σ p p1 (_ : {{ ⟦ σ ⟧s p ↘ p1 }}) : Prop := forall p2 (Heval2 : {{ ⟦ σ ⟧s p ↘ p2 }}), p1 = p2.
 
   #[local]
-  Ltac unfold_functional_eval := unfold functional_eval_exp_prop, functional_eval_natrec_prop, functional_eval_app_prop, functional_eval_sub_prop in *.
+  Ltac unfold_functional_eval :=
+    unfold functional_eval_exp_prop, functional_eval_natrec_prop, functional_eval_app_prop, functional_eval_sub_prop in *;
+    clear functional_eval_exp_prop functional_eval_natrec_prop functional_eval_app_prop functional_eval_sub_prop.
 
   Lemma functional_eval_exp : forall M p m1 (Heval1 : {{ ⟦ M ⟧ p ↘ m1 }}), functional_eval_exp_prop M p m1 Heval1.
   Proof using.
-    intros *.
     induction Heval1
       using eval_exp_mut_ind
       with (P0 := functional_eval_natrec_prop)
            (P1 := functional_eval_app_prop)
            (P2 := functional_eval_sub_prop);
       unfold_functional_eval; mauto;
-      intros; inversion Heval2; clear Heval2; subst; do 2 f_equal;
-      solve [mauto|erewrite IHHeval1 in *; mauto|erewrite IHHeval1_1, IHHeval1_2 in *; mauto].
+      intros; inversion_clear Heval2; subst; do 2 f_equal;
+      (on_all_hyp: fun H => try erewrite H in *; mauto); mauto.
   Qed.
 
   Lemma functional_eval_natrec : forall A MZ MS m p r1 (Heval1 : {{ rec m ⟦return A | zero -> MZ | succ -> MS end⟧ p ↘ r1 }}), functional_eval_natrec_prop A MZ MS m p r1 Heval1.
   Proof using.
-    intros *.
     induction Heval1
       using eval_natrec_mut_ind
       with (P := functional_eval_exp_prop)
@@ -33,12 +33,11 @@ Section functional_eval.
            (P2 := functional_eval_sub_prop);
       unfold_functional_eval; mauto;
       intros; inversion Heval2; clear Heval2; subst; do 2 f_equal;
-      solve [mauto|erewrite IHHeval1 in *; mauto|erewrite IHHeval1, IHHeval0 in *; mauto].
+      (on_all_hyp: fun H => try erewrite H in *; mauto); mauto.
   Qed.
 
   Lemma functional_eval_app : forall m n r1 (Heval1 : {{ $| m & n |↘ r1 }}), functional_eval_app_prop m n r1 Heval1.
   Proof using.
-    intros *.
     induction Heval1
       using eval_app_mut_ind
       with (P := functional_eval_exp_prop)
@@ -46,12 +45,11 @@ Section functional_eval.
            (P2 := functional_eval_sub_prop);
       unfold_functional_eval; mauto;
       intros; inversion Heval2; clear Heval2; subst; do 2 f_equal;
-      solve [mauto|erewrite IHHeval1 in *; mauto|erewrite IHHeval1, IHHeval0 in *; mauto].
+      (on_all_hyp: fun H => try erewrite H in *; mauto); mauto.
   Qed.
 
   Lemma functional_eval_sub : forall σ p p1 (Heval1 : {{ ⟦ σ ⟧s p ↘ p1 }}), functional_eval_sub_prop σ p p1 Heval1.
   Proof using.
-    intros *.
     induction Heval1
       using eval_sub_mut_ind
       with (P := functional_eval_exp_prop)
@@ -59,9 +57,21 @@ Section functional_eval.
            (P1 := functional_eval_app_prop);
       unfold_functional_eval; mauto;
       intros; inversion Heval2; clear Heval2; subst; do 2 f_equal;
-      try solve [mauto|erewrite IHHeval1 in *; mauto|erewrite IHHeval1, IHHeval0 in *; mauto|erewrite IHHeval1_1 in *; mauto].
+      (on_all_hyp: fun H => try erewrite H in *; mauto); mauto.
   Qed.
 End functional_eval.
 
 #[export]
 Hint Resolve functional_eval_exp functional_eval_natrec functional_eval_app functional_eval_sub : mcltt.
+
+Ltac functional_eval_rewrite_clear := 
+  repeat match goal with
+    | H1 : {{ ⟦ ~?M ⟧ ~?p ↘ ~?m1 }}, H2 : {{ ⟦ ~?M ⟧ ~?p ↘ ~?m2 }} |- _ =>
+        assert (m1 = m2) by mauto; subst; clear H2
+    | H1 : {{ $| ~?m & ~?n |↘ ~?r1 }}, H2 : {{ $| ~?m & ~?n |↘ ~?r2 }} |- _ =>
+        assert (r1 = r2) by mauto; subst; clear H2
+    | H1 : {{ rec ~?m ⟦return ~?A | zero -> ~?MZ | succ -> ~?MS end⟧ ~?p ↘ ~?r1 }}, H2 : {{ rec ~?m ⟦return ~?A | zero -> ~?MZ | succ -> ~?MS end⟧ ~?p ↘ ~?r2 }} |- _ =>
+        assert (r1 = r2) by mauto; subst; clear H2
+    | H1 : {{ ⟦ ~?σ ⟧s ~?p ↘ ~?p1 }}, H2 : {{ ⟦ ~?σ ⟧s ~?p ↘ ~?p2 }} |- _ =>
+        assert (p1 = p2) by mauto; subst; clear H2
+    end.

--- a/theories/Core/Semantic/ReadbackLemmas.v
+++ b/theories/Core/Semantic/ReadbackLemmas.v
@@ -18,12 +18,7 @@ Section functional_read.
            (P1 := functional_read_typ_prop);
       unfold_functional_read; mauto;
       intros; inversion Hread2; clear Hread2; subst;
-      try replace m'0 with m' in * by mauto;
-      try replace b0 with b in * by mauto;
-      try replace bz0 with bz in * by mauto;
-      try replace bs0 with bs in * by mauto;
-      try replace ms0 with ms in * by mauto;
-      f_equal...
+      functional_eval_rewrite_clear; f_equal...
   Qed.
 
   Lemma functional_read_ne : forall s m M1 (Hread1 : {{ Rne m in s ↘ M1 }}), functional_read_ne_prop s m M1 Hread1.
@@ -35,12 +30,7 @@ Section functional_read.
            (P1 := functional_read_typ_prop);
       unfold_functional_read; mauto;
       intros; inversion Hread2; clear Hread2; subst;
-      try replace m'0 with m' in * by mauto;
-      try replace b0 with b in * by mauto;
-      try replace bz0 with bz in * by mauto;
-      try replace bs0 with bs in * by mauto;
-      try replace ms0 with ms in * by mauto;
-      f_equal...
+      functional_eval_rewrite_clear; f_equal...
   Qed.
 
   Lemma functional_read_typ : forall s m M1 (Hread1 : {{ Rtyp m in s ↘ M1 }}), functional_read_typ_prop s m M1 Hread1.
@@ -52,14 +42,19 @@ Section functional_read.
            (P0 := functional_read_ne_prop);
       unfold_functional_read; mauto;
       intros; inversion Hread2; clear Hread2; subst;
-      try replace m'0 with m' in * by mauto;
-      try replace b0 with b in * by mauto;
-      try replace bz0 with bz in * by mauto;
-      try replace bs0 with bs in * by mauto;
-      try replace ms0 with ms in * by mauto;
-      f_equal...
+      functional_eval_rewrite_clear; f_equal...
   Qed.
 End functional_read.
 
-#[global]
+#[export]
 Hint Resolve functional_read_nf functional_read_ne functional_read_typ : mcltt.
+
+Ltac functional_read_rewrite_clear := 
+  repeat match goal with
+    | H1 : {{ Rnf ~?m in ?s ↘ ~?M1 }}, H2 : {{ Rnf ~?m in ?s ↘ ~?M2 }} |- _ =>
+        idtac H1; assert (M1 = M2) by mauto; subst; clear H2
+    | H1 : {{ Rne ~?m in ?s ↘ ~?M1 }}, H2 : {{ Rne ~?m in ?s ↘ ~?M2 }} |- _ =>
+        idtac H1; assert (M1 = M2) by mauto; subst; clear H2
+    | H1 : {{ Rtyp ~?m in ?s ↘ ~?M1 }}, H2 : {{ Rtyp ~?m in ?s ↘ ~?M2 }} |- _ =>
+        idtac H1; assert (M1 = M2) by mauto; subst; clear H2
+    end.

--- a/theories/Core/Syntactic/CtxEquiv.v
+++ b/theories/Core/Syntactic/CtxEquiv.v
@@ -20,7 +20,10 @@ ctxeq_sub_eq_helper : forall {Γ Γ' σ σ'}, {{ Γ ⊢s σ ≈ σ' : Γ' }} -> 
 Proof with solve [mauto].
   (* ctxeq_exp_helper *)
   - intros * HM * HΓΔ. gen Δ.
-    inversion_clear HM; (on_all_hyp: gen_ctxeq_helper_IH ctxeq_exp_helper ctxeq_exp_eq_helper ctxeq_sub_helper ctxeq_sub_eq_helper); clear ctxeq_exp_helper ctxeq_exp_eq_helper ctxeq_sub_helper ctxeq_sub_eq_helper; intros; destruct (presup_ctx_eq HΓΔ); mauto.
+    inversion_clear HM;
+      (on_all_hyp: gen_ctxeq_helper_IH ctxeq_exp_helper ctxeq_exp_eq_helper ctxeq_sub_helper ctxeq_sub_eq_helper);
+      clear ctxeq_exp_helper ctxeq_exp_eq_helper ctxeq_sub_helper ctxeq_sub_eq_helper;
+      intros; destruct (presup_ctx_eq HΓΔ); mauto.
     all: try (rename B into C); try (rename A0 into B).
     2-4: assert {{ Δ ⊢ B : Type@i }} as HB by eauto.
     2-4: assert {{ ⊢ Γ, B ≈ Δ, B }} by mauto; clear HB.
@@ -36,7 +39,10 @@ Proof with solve [mauto].
 
   (* ctxeq_exp_eq_helper *)
   - intros * HMM' * HΓΔ. gen Δ.
-    inversion_clear HMM'; (on_all_hyp: gen_ctxeq_helper_IH ctxeq_exp_helper ctxeq_exp_eq_helper ctxeq_sub_helper ctxeq_sub_eq_helper); clear ctxeq_exp_helper ctxeq_exp_eq_helper ctxeq_sub_helper ctxeq_sub_eq_helper; intros; destruct (presup_ctx_eq HΓΔ); mauto.
+    inversion_clear HMM';
+      (on_all_hyp: gen_ctxeq_helper_IH ctxeq_exp_helper ctxeq_exp_eq_helper ctxeq_sub_helper ctxeq_sub_eq_helper);
+      clear ctxeq_exp_helper ctxeq_exp_eq_helper ctxeq_sub_helper ctxeq_sub_eq_helper;
+      intros; destruct (presup_ctx_eq HΓΔ); mauto.
     all: try (rename B into C); try (rename B' into C'); try (rename A0 into B); try (rename A' into B').
     1-3: assert {{ ⊢ Γ, ℕ ≈ Δ, ℕ }} by (econstructor; mauto).
     1-3: assert {{ Δ, ℕ ⊢ B : Type@i }} by eauto.
@@ -52,13 +58,19 @@ Proof with solve [mauto].
 
   (* ctxeq_sub_helper *)
   - intros * Hσ * HΓΔ. gen Δ.
-    inversion_clear Hσ; (on_all_hyp: gen_ctxeq_helper_IH ctxeq_exp_helper ctxeq_exp_eq_helper ctxeq_sub_helper ctxeq_sub_eq_helper); clear ctxeq_exp_helper ctxeq_exp_eq_helper ctxeq_sub_helper ctxeq_sub_eq_helper; intros; destruct (presup_ctx_eq HΓΔ); mauto.
+    inversion_clear Hσ;
+      (on_all_hyp: gen_ctxeq_helper_IH ctxeq_exp_helper ctxeq_exp_eq_helper ctxeq_sub_helper ctxeq_sub_eq_helper);
+      clear ctxeq_exp_helper ctxeq_exp_eq_helper ctxeq_sub_helper ctxeq_sub_eq_helper;
+      intros; destruct (presup_ctx_eq HΓΔ); mauto.
     inversion_clear HΓΔ.
     econstructor...
 
   (* ctxeq_sub_eq_helper *)
   - intros * Hσσ' * HΓΔ. gen Δ.
-    inversion_clear Hσσ'; (on_all_hyp: gen_ctxeq_helper_IH ctxeq_exp_helper ctxeq_exp_eq_helper ctxeq_sub_helper ctxeq_sub_eq_helper); clear ctxeq_exp_helper ctxeq_exp_eq_helper ctxeq_sub_helper ctxeq_sub_eq_helper; intros; destruct (presup_ctx_eq HΓΔ); mauto.
+    inversion_clear Hσσ';
+      (on_all_hyp: gen_ctxeq_helper_IH ctxeq_exp_helper ctxeq_exp_eq_helper ctxeq_sub_helper ctxeq_sub_eq_helper);
+      clear ctxeq_exp_helper ctxeq_exp_eq_helper ctxeq_sub_helper ctxeq_sub_eq_helper;
+      intros; destruct (presup_ctx_eq HΓΔ); mauto.
     inversion_clear HΓΔ.
     eapply wf_sub_eq_conv...
 


### PR DESCRIPTION
This PR adds `functional_eval_rewrite_clear` and `functional_read_rewrite_clear` which helps us to exploit functionality of those propositions and remove some redundant hypotheses.