### PR TITLE
Update ci_build.yml

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           ocaml-compiler: ${{ env.OCAML_VER }}
           dune-cache: true
-          cache-prefix: "v2.1"
+          cache-prefix: "v2.2"
       - name: install Menhir and Coq
         run: |
           opam update


### PR DESCRIPTION
I don't know what keeps happening on the cache (or OCaml upstream). Cache keeps having old OCaml compiler and reinstall newer one.

Is there a "better" solution? IDK. Maybe the idea of using `setup-ocaml` itself is not so great...